### PR TITLE
feat: add Auth0 OAuth2 provider

### DIFF
--- a/src/Bee.OAuth2.AspNet/Bee.OAuth2.AspNet.csproj
+++ b/src/Bee.OAuth2.AspNet/Bee.OAuth2.AspNet.csproj
@@ -7,7 +7,7 @@
 		<Company>Bee.NET</Company>
 		<Product>Bee.NET</Product>
 		<Copyright>© Bee.NET. All rights reserved.</Copyright>
-		<Description>Bee.OAuth2.AspNet is an OAuth2 authentication library designed for ASP.NET WebForms / MVC, supporting Google, Facebook, LINE, and Azure.</Description>		
+                <Description>Bee.OAuth2.AspNet is an OAuth2 authentication library designed for ASP.NET WebForms / MVC, supporting Google, Facebook, LINE, Azure, and Auth0.</Description>
 		<PackageIcon>bee.png</PackageIcon>
 		<PackageTags>OAuth2 ASP.NET WebForms/MVC</PackageTags>
 		<PackageReleaseNotes></PackageReleaseNotes>

--- a/src/Bee.OAuth2.AspNet/README.md
+++ b/src/Bee.OAuth2.AspNet/README.md
@@ -1,6 +1,6 @@
 # Bee.OAuth2.AspNet
 
-Bee.OAuth2.AspNet is an OAuth2 authentication library designed for **ASP.NET WebForms / MVC**, supporting **Google, Facebook, LINE, and Azure**.
+Bee.OAuth2.AspNet is an OAuth2 authentication library designed for **ASP.NET WebForms / MVC**, supporting **Google, Facebook, LINE, Azure, and Auth0**.
 
 ## 📦 Installation
 
@@ -16,6 +16,7 @@ dotnet add package Bee.OAuth2.AspNet
 - ✅ Facebook
 - ✅ LINE
 - ✅ Azure (Microsoft Entra ID)
+- ✅ Auth0
 
 ## 🚀 Usage Example (ASP.NET WebForms)
 
@@ -143,7 +144,7 @@ This project is licensed under the MIT License.
 
 # Bee.OAuth2.AspNet（中文）
 
-Bee.OAuth2.AspNet 是一個專為 **ASP.NET WebForms / MVC** 設計的 OAuth2 認證函式庫，支援 **Google、Facebook、LINE、Azure** 等 OAuth2 提供者。
+Bee.OAuth2.AspNet 是一個專為 **ASP.NET WebForms / MVC** 設計的 OAuth2 認證函式庫，支援 **Google、Facebook、LINE、Azure、Auth0** 等 OAuth2 提供者。
 
 ## 📦 安裝方式
 
@@ -159,6 +160,7 @@ dotnet add package Bee.OAuth2.AspNet
 - ✅ Facebook
 - ✅ LINE
 - ✅ Azure（Microsoft Entra ID）
+- ✅ Auth0
 
 ## 🚀 使用範例（ASP.NET WebForms）
 

--- a/src/Bee.OAuth2.AspNetCore/Bee.OAuth2.AspNetCore.csproj
+++ b/src/Bee.OAuth2.AspNetCore/Bee.OAuth2.AspNetCore.csproj
@@ -7,7 +7,7 @@
 		<Company>Bee.NET</Company>
 		<Product>Bee.NET</Product>
 		<Copyright>© Bee.NET. All rights reserved.</Copyright>
-		<Description>Bee.OAuth2.AspNetCore is an OAuth2 authentication library designed for ASP.NET Core, supporting Google, Facebook, LINE, and Azure.</Description>
+                <Description>Bee.OAuth2.AspNetCore is an OAuth2 authentication library designed for ASP.NET Core, supporting Google, Facebook, LINE, Azure, and Auth0.</Description>
 		<PackageIcon>bee.png</PackageIcon>
 		<PackageTags>OAuth2 WinForms</PackageTags>
 		<PackageReleaseNotes></PackageReleaseNotes>

--- a/src/Bee.OAuth2.AspNetCore/README.md
+++ b/src/Bee.OAuth2.AspNetCore/README.md
@@ -1,7 +1,7 @@
 
 # Bee.OAuth2.AspNetCore
 
-Bee.OAuth2.AspNetCore is an ASP.NET Core library that simplifies OAuth2 authentication integration in your web applications. It supports **Google, Facebook, LINE, and Azure** via a centralized `TOAuth2Manager` with full DI support and PKCE.
+Bee.OAuth2.AspNetCore is an ASP.NET Core library that simplifies OAuth2 authentication integration in your web applications. It supports **Google, Facebook, LINE, Azure, and Auth0** via a centralized `TOAuth2Manager` with full DI support and PKCE.
 
 ## 📦 Installation
 
@@ -17,6 +17,7 @@ dotnet add package Bee.OAuth2.AspNetCore
 - ✅ Facebook
 - ✅ LINE
 - ✅ Azure (Microsoft Entra ID)
+- ✅ Auth0
 
 ## 🚀 Usage Example
 
@@ -122,7 +123,7 @@ This project is licensed under the MIT License.
 
 # Bee.OAuth2.AspNetCore（中文）
 
-Bee.OAuth2.AspNetCore 是一套針對 ASP.NET Core 網站設計的 OAuth2 認證整合函式庫。透過集中式的 `TOAuth2Manager` 搭配 DI 註冊，輕鬆整合 **Google、Facebook、LINE、Azure** 登入，並支援 PKCE 流程。
+Bee.OAuth2.AspNetCore 是一套針對 ASP.NET Core 網站設計的 OAuth2 認證整合函式庫。透過集中式的 `TOAuth2Manager` 搭配 DI 註冊，輕鬆整合 **Google、Facebook、LINE、Azure、Auth0** 登入，並支援 PKCE 流程。
 
 ## 📦 安裝方式
 
@@ -138,6 +139,7 @@ dotnet add package Bee.OAuth2.AspNetCore
 - ✅ Facebook
 - ✅ LINE
 - ✅ Azure（Microsoft Entra ID）
+- ✅ Auth0
 
 ## 🚀 使用範例
 

--- a/src/Bee.OAuth2.Desktop/Bee.OAuth2.Desktop.csproj
+++ b/src/Bee.OAuth2.Desktop/Bee.OAuth2.Desktop.csproj
@@ -7,7 +7,7 @@
 		<Company>Bee.NET</Company>
 		<Product>Bee.NET</Product>
 		<Copyright>© Bee.NET. All rights reserved.</Copyright>
-		<Description>Bee.OAuth2.Desktop is a Windows Forms library that provides a user interface for OAuth2 authentication. It supports Google, Facebook, LINE, and Azure authentication with an easy-to-use UI component.</Description>
+                <Description>Bee.OAuth2.Desktop is a Windows Forms library that provides a user interface for OAuth2 authentication. It supports Google, Facebook, LINE, Azure, and Auth0 authentication with an easy-to-use UI component.</Description>
 		<PackageIcon>bee.png</PackageIcon>
 		<PackageTags>OAuth2 WinForms</PackageTags>
 		<PackageReleaseNotes></PackageReleaseNotes>

--- a/src/Bee.OAuth2.Desktop/README.md
+++ b/src/Bee.OAuth2.Desktop/README.md
@@ -1,6 +1,6 @@
 # Bee.OAuth2.Desktop
 
-Bee.OAuth2.Desktop is a Windows Forms library that provides a user interface for OAuth2 authentication. It supports **Google, Facebook, LINE, and Azure** authentication with an easy-to-use UI component.
+Bee.OAuth2.Desktop is a Windows Forms library that provides a user interface for OAuth2 authentication. It supports **Google, Facebook, LINE, Azure, and Auth0** authentication with an easy-to-use UI component.
 
 ## 📦 Installation
 
@@ -16,6 +16,7 @@ dotnet add package Bee.OAuth2.Desktop
 - ✅ Facebook
 - ✅ LINE
 - ✅ Azure (Microsoft Entra ID)
+- ✅ Auth0
 
 ## 🚀 Usage Example
 
@@ -61,7 +62,7 @@ This project is licensed under the MIT License.
 
 # Bee.OAuth2.Desktop（中文）
 
-Bee.OAuth2.Desktop 是一個 Windows Forms 函式庫，提供 OAuth2 驗證的使用者介面。支援 **Google、Facebook、LINE 和 Azure** 的身份驗證，並內建易於使用的 UI 元件。
+Bee.OAuth2.Desktop 是一個 Windows Forms 函式庫，提供 OAuth2 驗證的使用者介面。支援 **Google、Facebook、LINE、Azure 以及 Auth0** 的身份驗證，並內建易於使用的 UI 元件。
 
 ## 📦 安裝方式
 
@@ -77,6 +78,7 @@ dotnet add package Bee.OAuth2.Desktop
 - ✅ Facebook
 - ✅ LINE
 - ✅ Azure（Microsoft Entra ID）
+- ✅ Auth0
 
 ## 🚀 使用範例
 

--- a/src/Bee.OAuth2.WinForms/Bee.OAuth2.WinForms.csproj
+++ b/src/Bee.OAuth2.WinForms/Bee.OAuth2.WinForms.csproj
@@ -7,7 +7,7 @@
 		<Company>Bee.NET</Company>
 		<Product>Bee.NET</Product>
 		<Copyright>© Bee.NET. All rights reserved.</Copyright>
-		<Description>Bee.OAuth2.WinForms is a Windows Forms library that provides a user interface for OAuth2 authentication. It supports Google, Facebook, LINE, and Azure authentication with an easy-to-use UI component.</Description>
+                <Description>Bee.OAuth2.WinForms is a Windows Forms library that provides a user interface for OAuth2 authentication. It supports Google, Facebook, LINE, Azure, and Auth0 authentication with an easy-to-use UI component.</Description>
 		<PackageIcon>bee.png</PackageIcon>
 		<PackageTags>OAuth2 WinForms</PackageTags>
 		<PackageReleaseNotes></PackageReleaseNotes>

--- a/src/Bee.OAuth2.WinForms/README.md
+++ b/src/Bee.OAuth2.WinForms/README.md
@@ -1,6 +1,6 @@
 # Bee.OAuth2.WinForms
 
-Bee.OAuth2.WinForms is a Windows Forms library that provides a user interface for OAuth2 authentication. It supports **Google, Facebook, LINE, and Azure** authentication with an easy-to-use UI component.
+Bee.OAuth2.WinForms is a Windows Forms library that provides a user interface for OAuth2 authentication. It supports **Google, Facebook, LINE, Azure, and Auth0** authentication with an easy-to-use UI component.
 
 ## 📦 Installation
 
@@ -16,6 +16,7 @@ dotnet add package Bee.OAuth2.WinForms
 - ✅ Facebook
 - ✅ LINE
 - ✅ Azure (Microsoft Entra ID)
+- ✅ Auth0
 
 ## 🚀 Usage Example
 
@@ -61,7 +62,7 @@ This project is licensed under the MIT License.
 
 # Bee.OAuth2.WinForms（中文）
 
-Bee.OAuth2.WinForms 是一個 Windows Forms 函式庫，提供 OAuth2 驗證的使用者介面。支援 **Google、Facebook、LINE 和 Azure** 的身份驗證，並內建易於使用的 UI 元件。
+Bee.OAuth2.WinForms 是一個 Windows Forms 函式庫，提供 OAuth2 驗證的使用者介面。支援 **Google、Facebook、LINE、Azure 以及 Auth0** 的身份驗證，並內建易於使用的 UI 元件。
 
 ## 📦 安裝方式
 
@@ -77,6 +78,7 @@ dotnet add package Bee.OAuth2.WinForms
 - ✅ Facebook
 - ✅ LINE
 - ✅ Azure（Microsoft Entra ID）
+- ✅ Auth0
 
 ## 🚀 使用範例
 

--- a/src/Bee.OAuth2/Auth0/Auth0OAuth2Options.cs
+++ b/src/Bee.OAuth2/Auth0/Auth0OAuth2Options.cs
@@ -1,0 +1,37 @@
+namespace Bee.OAuth2
+{
+    /// <summary>
+    /// Auth0 OAuth2 設定選項，包含 Domain、Client ID、Secret、Redirect URI 及相關端點。
+    /// </summary>
+    public class Auth0OAuth2Options : OAuth2Options
+    {
+        private string _domain = string.Empty;
+
+        /// <summary>
+        /// Auth0 Domain，例如: your-tenant.auth0.com。
+        /// 設定後會自動更新相關端點。
+        /// </summary>
+        public string Domain
+        {
+            get => _domain;
+            set
+            {
+                _domain = (value ?? string.Empty).TrimEnd('/');
+                if (string.IsNullOrEmpty(_domain))
+                    return;
+
+                AuthorizationEndpoint = $"https://{_domain}/authorize";
+                TokenEndpoint = $"https://{_domain}/oauth/token";
+                UserInfoEndpoint = $"https://{_domain}/userinfo";
+            }
+        }
+
+        /// <summary>
+        /// 建構函式。
+        /// </summary>
+        public Auth0OAuth2Options()
+        {
+            Scopes = new[] { "openid", "profile", "email" };
+        }
+    }
+}

--- a/src/Bee.OAuth2/Auth0/Auth0OAuth2Provider.cs
+++ b/src/Bee.OAuth2/Auth0/Auth0OAuth2Provider.cs
@@ -1,0 +1,44 @@
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace Bee.OAuth2
+{
+    /// <summary>
+    /// Auth0 OAuth2 驗證服務提供者，負責處理授權流程、交換 Access Token 及取得用戶資訊。
+    /// </summary>
+    public class Auth0OAuth2Provider : OAuth2Provider
+    {
+        /// <summary>
+        /// 建構函式。
+        /// </summary>
+        /// <param name="options">OAuth2 設定選項。</param>
+        public Auth0OAuth2Provider(Auth0OAuth2Options options) : base(options)
+        {
+        }
+
+        /// <summary>
+        /// OAuth2 驗證服務提供者名稱。
+        /// </summary>
+        public override string ProviderName { get; } = "Auth0";
+
+        /// <summary>
+        /// 解析用戶資訊 JSON 字串。
+        /// </summary>
+        /// <param name="json">用戶資訊 JSON 字串。</param>
+        public override UserInfo ParseUserJson(string json)
+        {
+            if (string.IsNullOrEmpty(json))
+                throw new ArgumentNullException(nameof(json), "JSON string cannot be null or empty.");
+
+            var jObject = JObject.Parse(json);
+
+            return new UserInfo
+            {
+                UserId = jObject["sub"]?.ToString(),
+                UserName = jObject["name"]?.ToString() ?? jObject["nickname"]?.ToString(),
+                Email = jObject["email"]?.ToString(),
+                RawJson = json
+            };
+        }
+    }
+}

--- a/src/Bee.OAuth2/Bee.OAuth2.csproj
+++ b/src/Bee.OAuth2/Bee.OAuth2.csproj
@@ -7,7 +7,7 @@
 		<Company>Bee.NET</Company>
 		<Product>Bee.NET</Product>
 		<Copyright>© Bee.NET. All rights reserved.</Copyright>
-		<Description>Bee.OAuth2 is a lightweight .NET OAuth2 authentication library that supports multiple providers, including Google, Facebook, LINE, and Azure.</Description>
+                <Description>Bee.OAuth2 is a lightweight .NET OAuth2 authentication library that supports multiple providers, including Google, Facebook, LINE, Azure, and Auth0.</Description>
 		<PackageIcon>bee.png</PackageIcon>
 		<PackageTags>OAuth2</PackageTags>
 		<PackageReleaseNotes></PackageReleaseNotes>

--- a/src/Bee.OAuth2/README.md
+++ b/src/Bee.OAuth2/README.md
@@ -1,6 +1,6 @@
 # Bee.OAuth2
 
-Bee.OAuth2 is a lightweight .NET OAuth2 authentication library that supports multiple providers, including Google, Facebook, LINE, and Azure.
+Bee.OAuth2 is a lightweight .NET OAuth2 authentication library that supports multiple providers, including Google, Facebook, LINE, Azure, and Auth0.
 
 ## Installation
 
@@ -16,6 +16,7 @@ dotnet add package Bee.OAuth2
 - Facebook
 - LINE
 - Azure (Microsoft Entra ID)
+- Auth0
 
 ## Usage Examples
 
@@ -96,6 +97,21 @@ var options = new AzureOAuth2Options
 var provider = new AzureOAuth2Provider(options);
 ```
 
+### Auth0 OAuth2 Authentication Example
+
+```csharp
+var options = new Auth0OAuth2Options
+{
+    Domain = "your-domain.auth0.com",
+    ClientId = "your-client-id",
+    ClientSecret = "your-client-secret",
+    RedirectUri = "http://localhost",
+    Scopes = { "openid", "profile", "email" }
+};
+
+var provider = new Auth0OAuth2Provider(options);
+```
+
 ## License
 
 This project is licensed under the MIT License.
@@ -104,7 +120,7 @@ This project is licensed under the MIT License.
 
 # Bee.OAuth2 (中文)
 
-Bee.OAuth2 是一個輕量級的 .NET OAuth2 驗證函式庫，支援 Google、Facebook、LINE 和 Azure（Microsoft Entra ID）。
+Bee.OAuth2 是一個輕量級的 .NET OAuth2 驗證函式庫，支援 Google、Facebook、LINE、Azure（Microsoft Entra ID）以及 Auth0。
 
 ## 安裝
 
@@ -120,6 +136,7 @@ dotnet add package Bee.OAuth2
 - Facebook
 - LINE
 - Azure（Microsoft Entra ID）
+- Auth0
 
 ## 使用範例
 
@@ -198,6 +215,21 @@ var options = new AzureOAuth2Options
 };
 
 var provider = new AzureOAuth2Provider(options);
+```
+
+### Auth0 OAuth2 驗證範例
+
+```csharp
+var options = new Auth0OAuth2Options
+{
+    Domain = "your-domain.auth0.com",
+    ClientId = "your-client-id",
+    ClientSecret = "your-client-secret",
+    RedirectUri = "http://localhost",
+    Scopes = { "openid", "profile", "email" }
+};
+
+var provider = new Auth0OAuth2Provider(options);
 ```
 
 ## 授權


### PR DESCRIPTION
## Summary
- add Auth0 options and provider to core OAuth2 library
- document Auth0 usage and list it as a supported provider across packages

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d948552488325905eb0f3e73dc82d