### PR TITLE
Add Okta OAuth2 provider support

### DIFF
--- a/samples/OAuthAspNet/App_Code/OAuthConfig.cs
+++ b/samples/OAuthAspNet/App_Code/OAuthConfig.cs
@@ -9,5 +9,6 @@ namespace OAuthAspNet
         public LineOAuth2Options LineOAuth { get; set; }
         public AzureOAuth2Options AzureOAuth { get; set; }
         public Auth0OAuth2Options Auth0OAuth { get; set; }
+        public OktaOAuth2Options OktaOAuth { get; set; }
     }
 }

--- a/samples/OAuthAspNet/App_Data/OAuthConfig.json
+++ b/samples/OAuthAspNet/App_Data/OAuthConfig.json
@@ -27,5 +27,12 @@
     "ClientId": "auth0-client-id",
     "ClientSecret": "auth0-client-secret",
     "RedirectUri": "https://localhost:44348/oauth2callback.aspx"
+  },
+  "OktaOAuth": {
+    "Domain": "your-domain.okta.com",
+    "AuthorizationServerId": "default",
+    "ClientId": "okta-client-id",
+    "ClientSecret": "okta-client-secret",
+    "RedirectUri": "https://localhost:44348/oauth2callback.aspx"
   }
 }

--- a/samples/OAuthAspNet/Global.asax.cs
+++ b/samples/OAuthAspNet/Global.asax.cs
@@ -19,7 +19,8 @@ namespace OAuthAspNet
             RegisterIfExists("Facebook", config?.FacebookOAuth);
             RegisterIfExists("Line", config?.LineOAuth);
             RegisterIfExists("Azure", config?.AzureOAuth);
-			RegisterIfExists("Auth0", config?.Auth0OAuth);
+                        RegisterIfExists("Auth0", config?.Auth0OAuth);
+            RegisterIfExists("Okta", config?.OktaOAuth);
         }
 
         private OAuthConfig LoadOAuthConfig(string filePath)

--- a/samples/OAuthAspNetCore/Extensions/OAuth2RegistrationHelper.cs
+++ b/samples/OAuthAspNetCore/Extensions/OAuth2RegistrationHelper.cs
@@ -17,6 +17,7 @@ namespace OAuthAspNetCore.Extensions
             RegisterIfExists(manager, "Line", config?.LineOAuth, accessor);
             RegisterIfExists(manager, "Azure", config?.AzureOAuth, accessor);
             RegisterIfExists(manager, "Auth0", config?.Auth0OAuth, accessor);
+            RegisterIfExists(manager, "Okta", config?.OktaOAuth, accessor);
             return manager;
         }
 

--- a/samples/OAuthAspNetCore/Models/OAuthConfig.cs
+++ b/samples/OAuthAspNetCore/Models/OAuthConfig.cs
@@ -9,5 +9,6 @@ namespace OAuthAspNetCore.Models
         public LineOAuth2Options? LineOAuth { get; set; }
         public AzureOAuth2Options? AzureOAuth { get; set; }
         public Auth0OAuth2Options? Auth0OAuth { get; set; }
+        public OktaOAuth2Options? OktaOAuth { get; set; }
     }
 }

--- a/samples/OAuthAspNetCore/OAuthConfig.json
+++ b/samples/OAuthAspNetCore/OAuthConfig.json
@@ -27,5 +27,12 @@
     "ClientId": "auth0-client-id",
     "ClientSecret": "auth0-client-secret",
     "RedirectUri": "https://localhost:7032/auth/callback"
+  },
+  "OktaOAuth": {
+    "Domain": "your-domain.okta.com",
+    "AuthorizationServerId": "default",
+    "ClientId": "okta-client-id",
+    "ClientSecret": "okta-client-secret",
+    "RedirectUri": "https://localhost:7032/auth/callback"
   }
 }

--- a/samples/OAuthDesktop/Form1.Designer.cs
+++ b/samples/OAuthDesktop/Form1.Designer.cs
@@ -34,6 +34,7 @@
             btnLine = new Button();
             btnAzure = new Button();
             btnAuth0 = new Button();
+            btnOkta = new Button();
             SuspendLayout();
             // 
             // btnGoogle
@@ -93,12 +94,23 @@
             btnAuth0.Text = "Auth0";
             btnAuth0.UseVisualStyleBackColor = true;
             btnAuth0.Click += btnAuth0_Click;
-            // 
+            //
+            // btnOkta
+            //
+            btnOkta.Location = new Point(417, 255);
+            btnOkta.Name = "btnOkta";
+            btnOkta.Size = new Size(75, 23);
+            btnOkta.TabIndex = 6;
+            btnOkta.Text = "Okta";
+            btnOkta.UseVisualStyleBackColor = true;
+            btnOkta.Click += btnOkta_Click;
+            //
             // Form1
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(505, 290);
+            Controls.Add(btnOkta);
             Controls.Add(btnAuth0);
             Controls.Add(btnAzure);
             Controls.Add(btnLine);
@@ -123,5 +135,6 @@
         private Button btnLine;
         private Button btnAzure;
         private Button btnAuth0;
+        private Button btnOkta;
     }
 }

--- a/samples/OAuthDesktop/Form1.cs
+++ b/samples/OAuthDesktop/Form1.cs
@@ -20,6 +20,7 @@ namespace OAuthDesktop
             RegisterIfExists("Line", 600, 800, config?.LineOAuth);
             RegisterIfExists("Azure", 800, 600, config?.AzureOAuth);
             RegisterIfExists("Auth0", 800, 600, config?.Auth0OAuth);
+            RegisterIfExists("Okta", 800, 600, config?.OktaOAuth);
         }
 
         private OAuthConfig LoadOAuthConfig(string filePath)
@@ -46,9 +47,9 @@ namespace OAuthDesktop
         }
 
         /// <summary>
-        /// Åã¥Ü OAuth2 ¾ã¦X»{ÃÒ¦^¶Çµ²ªG¡C
+        /// ï¿½ï¿½ï¿½ OAuth2 ï¿½ï¿½Xï¿½{ï¿½Ò¦^ï¿½Çµï¿½ï¿½Gï¿½C
         /// </summary>
-        /// <param name="result">±ÂÅv½X¨ú±o¬ÛÃö¸ê°Tªº¦^¶Çµ²ªG¡C</param>
+        /// <param name="result">ï¿½ï¿½ï¿½vï¿½Xï¿½ï¿½ï¿½oï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Tï¿½ï¿½ï¿½^ï¿½Çµï¿½ï¿½Gï¿½C</param>
         private void ShowResult(AuthorizationResult result)
         {
             if (result.Exception != null)
@@ -74,9 +75,9 @@ namespace OAuthDesktop
         }
 
         /// <summary>
-        /// °õ¦æµn¤J¡C
+        /// ï¿½ï¿½ï¿½ï¿½nï¿½Jï¿½C
         /// </summary>
-        /// <param name="clientName">¥Î¤áºÝ¦WºÙ¡C</param>
+        /// <param name="clientName">ï¿½Î¤ï¿½Ý¦Wï¿½Ù¡C</param>
         private async void Login(string clientName)
         {
             var result = await OAuth2Manager.Login(clientName);
@@ -106,6 +107,11 @@ namespace OAuthDesktop
         private void btnAuth0_Click(object sender, EventArgs e)
         {
             Login("Auth0");
+        }
+
+        private void btnOkta_Click(object sender, EventArgs e)
+        {
+            Login("Okta");
         }
     }
 }

--- a/samples/OAuthDesktop/OAuthConfig.cs
+++ b/samples/OAuthDesktop/OAuthConfig.cs
@@ -9,5 +9,6 @@ namespace OAuthDesktop
         public LineOAuth2Options? LineOAuth { get; set; }
         public AzureOAuth2Options? AzureOAuth { get; set; }
         public Auth0OAuth2Options? Auth0OAuth { get; set; }
+        public OktaOAuth2Options? OktaOAuth { get; set; }
     }
 }

--- a/samples/OAuthDesktop/OAuthConfig.json
+++ b/samples/OAuthDesktop/OAuthConfig.json
@@ -29,5 +29,13 @@
     "ClientSecret": "auth0-client-secret",
     "RedirectUri": "http://localhost/callback",
     "UsePKCE": true
+  },
+  "OktaOAuth": {
+    "Domain": "your-domain.okta.com",
+    "AuthorizationServerId": "default",
+    "ClientId": "okta-client-id",
+    "ClientSecret": "okta-client-secret",
+    "RedirectUri": "http://localhost/callback",
+    "UsePkce": true
   }
 }

--- a/samples/OAuthWinForms/Form1.Designer.cs
+++ b/samples/OAuthWinForms/Form1.Designer.cs
@@ -34,6 +34,7 @@
             this.btnLine = new System.Windows.Forms.Button();
             this.btnAzure = new System.Windows.Forms.Button();
             this.btnAuth0 = new System.Windows.Forms.Button();
+            this.btnOkta = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // btnGoogle
@@ -99,12 +100,24 @@
             this.btnAuth0.Text = "Auth0";
             this.btnAuth0.UseVisualStyleBackColor = true;
             this.btnAuth0.Click += new System.EventHandler(this.btnAuth0_Click);
-            // 
+
+            // btnOkta
+            //
+            this.btnOkta.Location = new System.Drawing.Point(556, 318);
+            this.btnOkta.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btnOkta.Name = "btnOkta";
+            this.btnOkta.Size = new System.Drawing.Size(100, 29);
+            this.btnOkta.TabIndex = 6;
+            this.btnOkta.Text = "Okta";
+            this.btnOkta.UseVisualStyleBackColor = true;
+            this.btnOkta.Click += new System.EventHandler(this.btnOkta_Click);
+            //
             // Form1
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(673, 362);
+            this.Controls.Add(this.btnOkta);
             this.Controls.Add(this.btnAuth0);
             this.Controls.Add(this.btnAzure);
             this.Controls.Add(this.btnLine);
@@ -131,6 +144,7 @@
         private System.Windows.Forms.Button btnLine;
         private System.Windows.Forms.Button btnAzure;
         private System.Windows.Forms.Button btnAuth0;
+        private System.Windows.Forms.Button btnOkta;
     }
 }
 

--- a/samples/OAuthWinForms/Form1.cs
+++ b/samples/OAuthWinForms/Form1.cs
@@ -23,6 +23,7 @@ namespace OAuthWinForms
             RegisterIfExists("Line", 600, 800, config?.LineOAuth);
             RegisterIfExists("Azure", 800, 600, config?.AzureOAuth);
             RegisterIfExists("Auth0", 800, 600, config?.Auth0OAuth);
+            RegisterIfExists("Okta", 800, 600, config?.OktaOAuth);
         }
 
         private OAuthConfig LoadOAuthConfig(string filePath)
@@ -109,6 +110,11 @@ namespace OAuthWinForms
         private void btnAuth0_Click(object sender, EventArgs e)
         {
             Login("Auth0");
+        }
+
+        private void btnOkta_Click(object sender, EventArgs e)
+        {
+            Login("Okta");
         }
     }
 }

--- a/samples/OAuthWinForms/OAuthConfig.cs
+++ b/samples/OAuthWinForms/OAuthConfig.cs
@@ -9,5 +9,6 @@ namespace OAuthWinForms
         public LineOAuth2Options LineOAuth { get; set; }
         public AzureOAuth2Options AzureOAuth { get; set; }
         public Auth0OAuth2Options Auth0OAuth { get; set; }
+        public OktaOAuth2Options OktaOAuth { get; set; }
     }
 }

--- a/samples/OAuthWinForms/OAuthConfig.json
+++ b/samples/OAuthWinForms/OAuthConfig.json
@@ -29,5 +29,13 @@
     "ClientSecret": "auth0-client-secret",
     "RedirectUri": "http://localhost/callback",
     "UsePKCE": true
+  },
+  "OktaOAuth": {
+    "Domain": "your-domain.okta.com",
+    "AuthorizationServerId": "default",
+    "ClientId": "okta-client-id",
+    "ClientSecret": "okta-client-secret",
+    "RedirectUri": "http://localhost/callback",
+    "UsePkce": true
   }
 }

--- a/src/Bee.OAuth2/Bee.OAuth2.csproj
+++ b/src/Bee.OAuth2/Bee.OAuth2.csproj
@@ -7,7 +7,7 @@
 		<Company>Bee.NET</Company>
 		<Product>Bee.NET</Product>
 		<Copyright>© Bee.NET. All rights reserved.</Copyright>
-                <Description>Bee.OAuth2 is a lightweight .NET OAuth2 authentication library that supports multiple providers, including Google, Facebook, LINE, Azure, and Auth0.</Description>
+                <Description>Bee.OAuth2 is a lightweight .NET OAuth2 authentication library that supports multiple providers, including Google, Facebook, LINE, Azure, Auth0, and Okta.</Description>
 		<PackageIcon>bee.png</PackageIcon>
 		<PackageTags>OAuth2</PackageTags>
 		<PackageReleaseNotes></PackageReleaseNotes>

--- a/src/Bee.OAuth2/Client/BaseOAuth2Client.cs
+++ b/src/Bee.OAuth2/Client/BaseOAuth2Client.cs
@@ -37,6 +37,8 @@ namespace Bee.OAuth2
                     return new FacebookOAuth2Provider(facebookOptions);
                 case Auth0OAuth2Options auth0Options:
                     return new Auth0OAuth2Provider(auth0Options);
+                case OktaOAuth2Options oktaOptions:
+                    return new OktaOAuth2Provider(oktaOptions);
                 default:
                     throw new NotSupportedException("Unsupported OAuth provider.");
             }

--- a/src/Bee.OAuth2/Okta/OktaOAuth2Options.cs
+++ b/src/Bee.OAuth2/Okta/OktaOAuth2Options.cs
@@ -1,0 +1,63 @@
+namespace Bee.OAuth2
+{
+    /// <summary>
+    /// Okta OAuth2 設定選項，包含 Domain、Authorization Server、Client ID、Secret、Redirect URI 及相關端點。
+    /// </summary>
+    public class OktaOAuth2Options : OAuth2Options
+    {
+        private string _domain = string.Empty;
+        private string _authorizationServerId = "default";
+
+        /// <summary>
+        /// Okta 網域，例如: dev-123456.okta.com 或 https://dev-123456.okta.com。
+        /// 設定後會自動更新相關端點。
+        /// </summary>
+        public string Domain
+        {
+            get => _domain;
+            set
+            {
+                _domain = (value ?? string.Empty).Trim().TrimEnd('/');
+                UpdateEndpoints();
+            }
+        }
+
+        /// <summary>
+        /// Okta 授權伺服器 ID，預設為 "default"。
+        /// 設定後會自動更新相關端點。
+        /// </summary>
+        public string AuthorizationServerId
+        {
+            get => _authorizationServerId;
+            set
+            {
+                _authorizationServerId = string.IsNullOrWhiteSpace(value) ? "default" : value.Trim().Trim('/') ;
+                UpdateEndpoints();
+            }
+        }
+
+        /// <summary>
+        /// 建構函式。
+        /// </summary>
+        public OktaOAuth2Options()
+        {
+            Scopes = new[] { "openid", "profile", "email" };
+        }
+
+        private void UpdateEndpoints()
+        {
+            if (string.IsNullOrEmpty(_domain))
+                return;
+
+            var baseUrl = _domain.StartsWith("http", System.StringComparison.OrdinalIgnoreCase)
+                ? _domain
+                : $"https://{_domain}";
+
+            var serverId = string.IsNullOrEmpty(_authorizationServerId) ? "default" : _authorizationServerId;
+
+            AuthorizationEndpoint = $"{baseUrl}/oauth2/{serverId}/v1/authorize";
+            TokenEndpoint = $"{baseUrl}/oauth2/{serverId}/v1/token";
+            UserInfoEndpoint = $"{baseUrl}/oauth2/{serverId}/v1/userinfo";
+        }
+    }
+}

--- a/src/Bee.OAuth2/Okta/OktaOAuth2Provider.cs
+++ b/src/Bee.OAuth2/Okta/OktaOAuth2Provider.cs
@@ -1,0 +1,44 @@
+using System;
+using Newtonsoft.Json.Linq;
+
+namespace Bee.OAuth2
+{
+    /// <summary>
+    /// Okta OAuth2 驗證服務提供者，負責處理授權流程、交換 Access Token 及取得用戶資訊。
+    /// </summary>
+    public class OktaOAuth2Provider : OAuth2Provider
+    {
+        /// <summary>
+        /// 建構函式。
+        /// </summary>
+        /// <param name="options">OAuth2 設定選項。</param>
+        public OktaOAuth2Provider(OktaOAuth2Options options) : base(options)
+        {
+        }
+
+        /// <summary>
+        /// OAuth2 驗證服務提供者名稱。
+        /// </summary>
+        public override string ProviderName { get; } = "Okta";
+
+        /// <summary>
+        /// 解析用戶資訊 JSON 字串。
+        /// </summary>
+        /// <param name="json">用戶資訊 JSON 字串。</param>
+        public override UserInfo ParseUserJson(string json)
+        {
+            if (string.IsNullOrEmpty(json))
+                throw new ArgumentNullException(nameof(json), "JSON string cannot be null or empty.");
+
+            var jObject = JObject.Parse(json);
+
+            return new UserInfo
+            {
+                UserId = jObject["sub"]?.ToString(),
+                UserName = jObject["name"]?.ToString() ?? jObject["preferred_username"]?.ToString(),
+                Email = jObject["email"]?.ToString(),
+                RawJson = json
+            };
+        }
+    }
+}

--- a/src/Bee.OAuth2/README.md
+++ b/src/Bee.OAuth2/README.md
@@ -1,6 +1,6 @@
 # Bee.OAuth2
 
-Bee.OAuth2 is a lightweight .NET OAuth2 authentication library that supports multiple providers, including Google, Facebook, LINE, Azure, and Auth0.
+Bee.OAuth2 is a lightweight .NET OAuth2 authentication library that supports multiple providers, including Google, Facebook, LINE, Azure, Auth0, and Okta.
 
 ## Installation
 
@@ -17,6 +17,7 @@ dotnet add package Bee.OAuth2
 - LINE
 - Azure (Microsoft Entra ID)
 - Auth0
+- Okta
 
 ## Usage Examples
 
@@ -112,6 +113,22 @@ var options = new Auth0OAuth2Options
 var provider = new Auth0OAuth2Provider(options);
 ```
 
+### Okta OAuth2 Authentication Example
+
+```csharp
+var options = new OktaOAuth2Options
+{
+    Domain = "your-domain.okta.com",
+    AuthorizationServerId = "default",
+    ClientId = "your-client-id",
+    ClientSecret = "your-client-secret",
+    RedirectUri = "http://localhost",
+    Scopes = { "openid", "profile", "email" }
+};
+
+var provider = new OktaOAuth2Provider(options);
+```
+
 ## License
 
 This project is licensed under the MIT License.
@@ -120,7 +137,7 @@ This project is licensed under the MIT License.
 
 # Bee.OAuth2 (中文)
 
-Bee.OAuth2 是一個輕量級的 .NET OAuth2 驗證函式庫，支援 Google、Facebook、LINE、Azure（Microsoft Entra ID）以及 Auth0。
+Bee.OAuth2 是一個輕量級的 .NET OAuth2 驗證函式庫，支援 Google、Facebook、LINE、Azure（Microsoft Entra ID）、Auth0 以及 Okta。
 
 ## 安裝
 
@@ -137,6 +154,7 @@ dotnet add package Bee.OAuth2
 - LINE
 - Azure（Microsoft Entra ID）
 - Auth0
+- Okta
 
 ## 使用範例
 


### PR DESCRIPTION
## Summary
- add Okta OAuth2 option and provider implementation to the core library and wire it into the base client
- update documentation and package metadata to list Okta support
- extend sample apps and configuration files with Okta settings and UI entries

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937987f4a008325ab21aeebf44f6144)